### PR TITLE
link to the component documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,11 @@ Welcome to Plasma Group!
 Hello! This is the documentation for general Plasma Group things.
 Here you'll find topics like how to write good documentation, how to create good pull requests, and so much more.
 
+Documentation for the components can be found here:
+
+* `plasma-core <https://plasma-core.readthedocs.io/>`_
+* `plasma-extension <https://plasma-extension.readthedocs.io/>`_
+
 .. toctree::
    :maxdepth: 2
    :caption: Guides


### PR DESCRIPTION
When I clicked on the documentation link on the bottom of https://plasma.group I expected to find some technical documentation. I think this could be the case for other people as well, so I suggest to add some links to those documentations.

I don't know if I missed any other components.